### PR TITLE
Use git sha1 for docker_tag to avoid already checkout

### DIFF
--- a/lib/capistrano/tasks/docker.rake
+++ b/lib/capistrano/tasks/docker.rake
@@ -36,9 +36,10 @@ namespace :docker do
     on fetch(:docker_build_server_host) do
       within dockerbuild_plugin.docker_build_base_path do
         timestamp = Time.now.to_i
-        worktree_dir_name = "worktree-#{fetch(:docker_tag)}-#{timestamp}"
+        git_sha1 = `git rev-parse #{fetch(:branch)}`.chomp
+        worktree_dir_name = "worktree-#{git_sha1}-#{timestamp}"
 
-        execute(:git, :worktree, :add, worktree_dir_name, fetch(:branch))
+        execute(:git, :worktree, :add, worktree_dir_name, git_sha1)
 
         begin
           within worktree_dir_name do


### PR DESCRIPTION
workingtree作成時に、bareのbranch名でcheckoutしようとすると既にcheckout済みである旨のエラーでましたので、workingtreeはgit sha1を元に作成するようにしてみました。
上記の変更に伴い、dockerのtagにもsha1が利用されるようになります。

`worktree add` example

```
# master sha1
% git rev-parse master
914d27fc7cf2464d5bfafc2294d8e3b4c196593e

# error
$ git worktree add worktree-master-1504072763 master
fatal: 'master' is already checked out at xxx

# use sha1
$ git worktree add worktree-914d27fc7cf2464d5bfafc2294d8e3b4c196593e-1504072763 914d27fc7cf2464d5bfafc2294d8e3b4c196593e
```

どうでしょうか？