### PR TITLE
Introduce git_gc_prune_date

### DIFF
--- a/lib/capistrano/dockerbuild.rb
+++ b/lib/capistrano/dockerbuild.rb
@@ -9,6 +9,7 @@ class Capistrano::Dockerbuild < Capistrano::Plugin
     set_if_empty :docker_remote_tag_full, -> { "#{fetch(:docker_registry) &.+ "/"}#{fetch(:docker_remote_repository_name)}:#{fetch(:docker_remote_tag)}" }
     set_if_empty :docker_latest_tag, false
     set_if_empty :keep_docker_image_count, 10
+    set_if_empty :git_gc_prune_date, "3.days.ago"
   end
 
   def define_tasks

--- a/lib/capistrano/tasks/docker.rake
+++ b/lib/capistrano/tasks/docker.rake
@@ -49,7 +49,7 @@ namespace :docker do
           execute(:rm, "-rf", worktree_dir_name)
           execute(:git, :worktree, :prune)
           # Execute "git gc" manually to avoid "There are too many unreachable loose objects" warning
-          execute(:git, :gc, "--auto", "--prune=3.days.ago")
+          execute(:git, :gc, "--auto", "--prune=#{fetch(:git_gc_prune_date)}")
         end
       end
     end


### PR DESCRIPTION
We sometimes receive errors like below
so we want to adjust the value:

```
git stdout: Nothing written
git stderr: Auto packing the repository in background for optimum performance.
See "git help gc" for manual housekeeping.
error: The last gc run reported the following. Please correct the root cause
and remove gc.log.
Automatic cleanup will not be performed until the file is removed.
```