### PR TITLE
Add docker_build_no_worktree option not to use worktree on build server

### DIFF
--- a/capistrano-dockerbuild.gemspec
+++ b/capistrano-dockerbuild.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "capistrano", ">= 3.2"
 
-  spec.add_development_dependency "bundler", "~> 1.15"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.3"
+  spec.add_development_dependency "rake", "~> 13.0"
 end

--- a/lib/capistrano/dockerbuild.rb
+++ b/lib/capistrano/dockerbuild.rb
@@ -10,6 +10,7 @@ class Capistrano::Dockerbuild < Capistrano::Plugin
     set_if_empty :docker_latest_tag, false
     set_if_empty :keep_docker_image_count, 10
     set_if_empty :git_gc_prune_date, "3.days.ago"
+    set_if_empty :docker_build_no_worktree, false
   end
 
   def define_tasks

--- a/lib/capistrano/tasks/docker.rake
+++ b/lib/capistrano/tasks/docker.rake
@@ -62,7 +62,7 @@ namespace :docker do
             execute(:rm, "-rf", worktree_dir_name)
             execute(:git, :worktree, :prune)
             # Execute "git gc" manually to avoid "There are too many unreachable loose objects" warning
-            execute(:git, :gc, "--auto", "--prune=3.days.ago")
+            execute(:git, :gc, "--auto", "--prune=#{fetch(:git_gc_prune_date)}")
           end
         end
       end

--- a/lib/capistrano/tasks/docker.rake
+++ b/lib/capistrano/tasks/docker.rake
@@ -50,9 +50,10 @@ namespace :docker do
           execute(:flock, "capistrano_dockerbuild.lock", "-c", "'#{commands}'")
         else
           timestamp = Time.now.to_i
-          worktree_dir_name = "worktree-#{fetch(:docker_tag)}-#{timestamp}"
+          git_sha1 = `git rev-parse #{fetch(:branch)}`.chomp
+          worktree_dir_name = "worktree-#{git_sha1}-#{timestamp}"
 
-          execute(:git, :worktree, :add, worktree_dir_name, fetch(:branch))
+          execute(:git, :worktree, :add, worktree_dir_name, git_sha1)
 
           begin
             within worktree_dir_name do


### PR DESCRIPTION
Add no worktree mode because [gradle-git-version](https://github.com/palantir/gradle-git-version) doesn't support worktree. 