### PR TITLE
Use git_repo_url instead of repo_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,24 @@ Use common variables
 | docker_remote_tag             | no       | `-> { fetch(:docker_tag) }`                                                                                        | Use by `docker push docker_registry/docker_remote_repository_name:{{docker_remote_tag}}` |
 | docker_remote_tag_full        | no       | `-> { "#{fetch(:docker_registry) &.+ "/"}#{fetch(:docker_remote_repository_name)}:#{fetch(:docker_remote_tag)}" }` | Use by `docker push {{docker_remote_tag_full}}`                                          |
 | keep_docker_image_count       | no       | 10                                                                                                                 |                                                                                          |
+| git_http_username             | no       | nil                                                                                                                | See below                                                                                |
+| git_http_password             | no       | nil                                                                                                                | See below                                                                                |
 
+If you want to use GitHub Apps installation access token or something to authorize repository access using HTTPS protocol. You can set variables in your config/deploy.rb:
+
+```ruby
+set :git_http_username, -> { ENV["GIT_HTTP_USERNAME"] }
+set :git_http_password, -> { ENV["GIT_HTTP_PASSWORD"] }
+set :repo_url, -> do
+  if fetch(:git_http_username) && fetch(:git_http_password)
+    "https://github.com/owner/repo.git"
+  else
+    "git@github.com:owner/repo.git"
+  end
+end
+```
+
+Update remote URL always if you set proper value to all of `repo_url`, `git_http_username`, and `git_http_password`.
 
 ## Tasks
 

--- a/lib/capistrano/dockerbuild.rb
+++ b/lib/capistrano/dockerbuild.rb
@@ -1,3 +1,6 @@
+require "cgi"
+require "uri"
+
 class Capistrano::Dockerbuild < Capistrano::Plugin
   def set_defaults
     set_if_empty :docker_build_cmd, -> { [:docker, "build", "-t", fetch(:docker_tag_full), "."] }
@@ -20,5 +23,20 @@ class Capistrano::Dockerbuild < Capistrano::Plugin
   def docker_build_base_path
     raise "Need to set :docker_build_base_dir" unless fetch(:docker_build_base_dir)
     Pathname(fetch(:docker_build_base_dir))
+  end
+
+  def git_repo_url
+    if fetch(:git_http_username) && fetch(:git_http_password)
+      URI.parse(repo_url).tap do |repo_uri|
+        repo_uri.user     = fetch(:git_http_username)
+        repo_uri.password = CGI.escape(fetch(:git_http_password))
+      end.to_s
+    elsif fetch(:git_http_username)
+      URI.parse(repo_url).tap do |repo_uri|
+        repo_uri.user = fetch(:git_http_username)
+      end.to_s
+    else
+      repo_url
+    end
   end
 end

--- a/lib/capistrano/tasks/docker.rake
+++ b/lib/capistrano/tasks/docker.rake
@@ -5,7 +5,7 @@ namespace :docker do
   task :check do
     on fetch(:docker_build_server_host) do
       execute :mkdir, "-p", dockerbuild_plugin.docker_build_base_path.dirname.to_s
-      execute :git, :'ls-remote', repo_url, "HEAD"
+      execute :git, :'ls-remote', dockerbuild_plugin.git_repo_url, "HEAD"
     end
   end
 
@@ -17,7 +17,7 @@ namespace :docker do
           info "The repository is at #{dockerbuild_plugin.docker_build_base_path}"
         else
           within dockerbuild_plugin.docker_build_base_path.dirname do
-            execute :git, :clone, repo_url, dockerbuild_plugin.docker_build_base_path.to_s
+            execute :git, :clone, dockerbuild_plugin.git_repo_url, dockerbuild_plugin.docker_build_base_path.to_s
           end
         end
       else
@@ -25,7 +25,7 @@ namespace :docker do
           info t(:mirror_exists, at: dockerbuild_plugin.docker_build_base_path.to_s)
         else
           within dockerbuild_plugin.docker_build_base_path.dirname do
-            execute :git, :clone, "--mirror", repo_url, dockerbuild_plugin.docker_build_base_path.to_s
+            execute :git, :clone, "--mirror", dockerbuild_plugin.git_repo_url, dockerbuild_plugin.docker_build_base_path.to_s
           end
         end
       end
@@ -36,6 +36,7 @@ namespace :docker do
   task update_mirror: :'docker:clone' do
     on fetch(:docker_build_server_host) do
       within dockerbuild_plugin.docker_build_base_path do
+        execute :git, :remote, "set-url", :origin, dockerbuild_plugin.git_repo_url
         execute :git, :remote, :update, "--prune"
       end
     end


### PR DESCRIPTION
to support https://github.com/owner/repo.git style remote url. 
This will support git_http_username and git_http_password to fetch remote.