### PR TITLE
add `docker:push_unless_exists`

### DIFF
--- a/lib/capistrano/tasks/docker.rake
+++ b/lib/capistrano/tasks/docker.rake
@@ -82,6 +82,14 @@ namespace :docker do
     end
   end
 
+  task :push_unless_exists => [:'docker:build'] do
+    on fetch(:docker_build_server_host) do
+      unless test "docker manifest inspect #{fetch(:docker_remote_tag_full)}"
+        invoke "docker:push"
+      end
+    end
+  end
+
   task :cleanup_local_images do
     on fetch(:docker_build_server_host) do
       local_images = []


### PR DESCRIPTION
I'd like to add a task to push Docker images only if they don't already exist in the remote repository.

ref. https://stackoverflow.com/questions/32113330/check-if-imagetag-combination-already-exists-on-docker-hub