### PR TITLE
feat: support git HTTP authentication via temporary gitconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Use common variables
 | keep_docker_image_count       | no       | 10                                                                                                                 |                                                                                          |
 | git_http_username             | no       | nil                                                                                                                | See below                                                                                |
 | git_http_password             | no       | nil                                                                                                                | See below                                                                                |
+| git_auth_token                | no       | nil                                                                                                                | See below                                                                                |
+| update_git_submodule          | no       | false                                                                                                              | Run `git submodule update --init --recursive` after checkout                             |
 
 If you want to use GitHub Apps installation access token or something to authorize repository access using HTTPS protocol. You can set variables in your config/deploy.rb:
 
@@ -105,7 +107,31 @@ end
 
 Update remote URL always if you set proper value to all of `repo_url`, `git_http_username`, and `git_http_password`.
 
+Alternatively, you can authenticate via an HTTP `Authorization` header using `:git_auth_token`. This is useful when the build server has no SSH key access to the repository (e.g. using a GitHub Apps installation access token or a personal access token).
+
+```ruby
+set :git_auth_token, -> { ENV["GIT_AUTH_TOKEN"] }
+set :repo_url, "git@github.com:owner/repo.git"  # SSH or HTTPS both work
+```
+
+When `:git_auth_token` is set, `docker:setup` creates a temporary `.gitconfig` on each remote build host containing:
+
+- `http.extraheader = Authorization: Basic <token>` — injects the token into every HTTPS git request
+- `url."https://<host>/".insteadOf` rules — rewrites SSH-style URLs (`git@host:` and `ssh://git@host/`) to HTTPS so the token is used regardless of how `repo_url` is written
+
+The host is derived automatically from `:repo_url`, so this works with GitHub, GitLab, Bitbucket, or any self-hosted git server.
+
+The temporary directory is removed automatically by `docker:clean` after `docker:build`.
+
 ## Tasks
+
+#### docker:setup
+- Create a temporary `.gitconfig` on each remote build host when `:git_auth_token` is set
+- Automatically invoked before `docker:check`
+
+#### docker:clean
+- Remove the temporary directory created by `docker:setup`
+- Automatically invoked after `docker:build`
 
 #### docker:check
 - Ensure `#{docker_build_base_dir}`
@@ -132,7 +158,9 @@ Update remote URL always if you set proper value to all of `repo_url`, `git_http
 
 ## Task Dependency
 
-docker:push => docker:build => docker:update_mirror => docker:clone => docker:check
+docker:push => docker:build => docker:update_mirror => docker:clone => docker:check => docker:setup
+
+docker:clean is triggered automatically after docker:build
 
 ## Development
 

--- a/lib/capistrano/dockerbuild.rb
+++ b/lib/capistrano/dockerbuild.rb
@@ -42,6 +42,10 @@ class Capistrano::Dockerbuild < Capistrano::Plugin
     end
   end
 
+  def git_repo_host
+    URI.parse(repo_url.sub(/^git@.*/) {|m| "https://#{m}" }).host
+  end
+
   def tmp_home(host)
     @tmp_host ||= {}
     @tmp_host[host.properties.arch] ||= Dir.mktmpdir(host.properties.arch) {|s| s }

--- a/lib/capistrano/dockerbuild.rb
+++ b/lib/capistrano/dockerbuild.rb
@@ -15,6 +15,7 @@ class Capistrano::Dockerbuild < Capistrano::Plugin
     set_if_empty :keep_docker_image_count, 10
     set_if_empty :git_gc_prune_date, "3.days.ago"
     set_if_empty :docker_build_no_worktree, false
+    set_if_empty :update_git_submodule, false
   end
 
   def define_tasks
@@ -39,5 +40,17 @@ class Capistrano::Dockerbuild < Capistrano::Plugin
     else
       repo_url
     end
+  end
+
+  def tmp_home(host)
+    @tmp_host ||= {}
+    @tmp_host[host.properties.arch] ||= Dir.mktmpdir(host.properties.arch) {|s| s }
+  end
+
+  def git_env(host)
+    return {} if fetch(:git_auth_token).to_s.empty?
+
+    @git_env ||= {}
+    @git_env[host.properties.arch] ||= { HOME: tmp_home(host), GIT_CONFIG_NOSYSTEM: "1" }
   end
 end

--- a/lib/capistrano/dockerbuild.rb
+++ b/lib/capistrano/dockerbuild.rb
@@ -1,5 +1,6 @@
 require "cgi"
 require "uri"
+require "securerandom"
 
 class Capistrano::Dockerbuild < Capistrano::Plugin
   def set_defaults
@@ -48,7 +49,7 @@ class Capistrano::Dockerbuild < Capistrano::Plugin
 
   def tmp_home(host)
     @tmp_host ||= {}
-    @tmp_host[host.properties.arch] ||= Dir.mktmpdir(host.properties.arch) {|s| s }
+    @tmp_host[host.properties.arch] ||= "/tmp/capistrano-dockerbuild-#{SecureRandom.hex(8)}"
   end
 
   def git_env(host)

--- a/lib/capistrano/tasks/docker.rake
+++ b/lib/capistrano/tasks/docker.rake
@@ -6,10 +6,11 @@ namespace :docker do
     on roles(:docker_build) do |host|
       unless fetch(:git_auth_token).to_s.empty?
         tmp_home = dockerbuild_plugin.tmp_home(host)
+        git_host = dockerbuild_plugin.git_repo_host
         execute :mkdir, "-p", tmp_home
         execute :git, :config, "--file", "#{tmp_home}/.gitconfig", "http.extraheader", "'Authorization: Basic #{fetch(:git_auth_token)}'"
-        execute :git, :config, "--file", "#{tmp_home}/.gitconfig", 'url."https://github.com/".insteadOf', "git@github.com:"
-        execute :git, :config, "--file", "#{tmp_home}/.gitconfig", "--add", 'url."https://github.com/".insteadOf', "ssh://git@github.com/"
+        execute :git, :config, "--file", "#{tmp_home}/.gitconfig", %Q(url."https://#{git_host}/".insteadOf), "git@#{git_host}:"
+        execute :git, :config, "--file", "#{tmp_home}/.gitconfig", "--add", %Q(url."https://#{git_host}/".insteadOf), "ssh://git@#{git_host}/"
       end
     end
   end

--- a/lib/capistrano/tasks/docker.rake
+++ b/lib/capistrano/tasks/docker.rake
@@ -1,11 +1,36 @@
 dockerbuild_plugin = self
 
 namespace :docker do
-  desc "check directory exist"
-  task :check do
+  desc "setup temporary gitconfig for HTTP authentication"
+  task :setup do
     on roles(:docker_build) do |host|
-      execute :mkdir, "-p", dockerbuild_plugin.docker_build_base_path.dirname.to_s
-      execute :git, :'ls-remote', dockerbuild_plugin.git_repo_url, "HEAD"
+      unless fetch(:git_auth_token).to_s.empty?
+        tmp_home = dockerbuild_plugin.tmp_home(host)
+        execute :mkdir, "-p", tmp_home
+        execute :git, :config, "--file", "#{tmp_home}/.gitconfig", "http.extraheader", "'Authorization: Basic #{fetch(:git_auth_token)}'"
+        execute :git, :config, "--file", "#{tmp_home}/.gitconfig", 'url."https://github.com/".insteadOf', "git@github.com:"
+        execute :git, :config, "--file", "#{tmp_home}/.gitconfig", "--add", 'url."https://github.com/".insteadOf', "ssh://git@github.com/"
+      end
+    end
+  end
+
+  desc "clean up temporary gitconfig"
+  task :clean do
+    on roles(:docker_build) do |host|
+      unless fetch(:git_auth_token).to_s.empty?
+        tmp_home = dockerbuild_plugin.tmp_home(host)
+        execute :rm, "-rf", tmp_home
+      end
+    end
+  end
+
+  desc "check directory exist"
+  task check: [:"docker:setup"] do
+    on roles(:docker_build) do |host|
+      with dockerbuild_plugin.git_env(host) do
+        execute :mkdir, "-p", dockerbuild_plugin.docker_build_base_path.dirname.to_s
+        execute :git, :'ls-remote', dockerbuild_plugin.git_repo_url, "HEAD"
+      end
     end
   end
 
@@ -17,7 +42,16 @@ namespace :docker do
           info "The repository is at #{dockerbuild_plugin.docker_build_base_path}"
         else
           within dockerbuild_plugin.docker_build_base_path.dirname do
-            execute :git, :clone, dockerbuild_plugin.git_repo_url, dockerbuild_plugin.docker_build_base_path.to_s
+            with dockerbuild_plugin.git_env(host) do
+              execute :git, :clone, dockerbuild_plugin.git_repo_url, dockerbuild_plugin.docker_build_base_path.to_s
+            end
+          end
+          if fetch(:update_git_submodule)
+            within dockerbuild_plugin.docker_build_base_path do
+              with dockerbuild_plugin.git_env(host) do
+                execute :git, :submodule, :update, "--init", "--recursive"
+              end
+            end
           end
         end
       else
@@ -25,7 +59,9 @@ namespace :docker do
           info t(:mirror_exists, at: dockerbuild_plugin.docker_build_base_path.to_s)
         else
           within dockerbuild_plugin.docker_build_base_path.dirname do
-            execute :git, :clone, "--mirror", dockerbuild_plugin.git_repo_url, dockerbuild_plugin.docker_build_base_path.to_s
+            with dockerbuild_plugin.git_env(host) do
+              execute :git, :clone, "--mirror", dockerbuild_plugin.git_repo_url, dockerbuild_plugin.docker_build_base_path.to_s
+            end
           end
         end
       end
@@ -36,8 +72,10 @@ namespace :docker do
   task update_mirror: :'docker:clone' do
     on roles(:docker_build) do |host|
       within dockerbuild_plugin.docker_build_base_path do
-        execute :git, :remote, "set-url", :origin, dockerbuild_plugin.git_repo_url
-        execute :git, :remote, :update, "--prune"
+        with dockerbuild_plugin.git_env(host) do
+          execute :git, :remote, "set-url", :origin, dockerbuild_plugin.git_repo_url
+          execute :git, :remote, :update, "--prune"
+        end
       end
     end
   end
@@ -66,6 +104,11 @@ namespace :docker do
 
           begin
             within worktree_dir_name do
+              if fetch(:update_git_submodule)
+                with dockerbuild_plugin.git_env(host) do
+                  execute :git, :submodule, :update, "--init", "--recursive"
+                end
+              end
               execute(*build_cmd)
             end
           ensure
@@ -136,3 +179,5 @@ namespace :docker do
     end
   end
 end
+
+after "docker:build", "docker:clean"

--- a/lib/capistrano/tasks/docker.rake
+++ b/lib/capistrano/tasks/docker.rake
@@ -47,13 +47,6 @@ namespace :docker do
               execute :git, :clone, dockerbuild_plugin.git_repo_url, dockerbuild_plugin.docker_build_base_path.to_s
             end
           end
-          if fetch(:update_git_submodule)
-            within dockerbuild_plugin.docker_build_base_path do
-              with dockerbuild_plugin.git_env(host) do
-                execute :git, :submodule, :update, "--init", "--recursive"
-              end
-            end
-          end
         end
       else
         if test " [ -f #{dockerbuild_plugin.docker_build_base_path}/HEAD ] "
@@ -94,8 +87,11 @@ namespace :docker do
       end
       within dockerbuild_plugin.docker_build_base_path do
         if fetch(:docker_build_no_worktree)
-          commands = "sha1=$(git rev-parse #{fetch(:branch)}); git reset --hard ${sha1}; #{build_cmd.map {|c| c.to_s.shellescape }.join(" ")}"
-          execute(:flock, "capistrano_dockerbuild.lock", "-c", "'#{commands}'")
+          submodule_cmd = fetch(:update_git_submodule) ? "; git submodule update --init --recursive" : ""
+          commands = "sha1=$(git rev-parse #{fetch(:branch)}); git reset --hard ${sha1}#{submodule_cmd}; #{build_cmd.map {|c| c.to_s.shellescape }.join(" ")}"
+          with dockerbuild_plugin.git_env(host) do
+            execute(:flock, "capistrano_dockerbuild.lock", "-c", "'#{commands}'")
+          end
         else
           timestamp = Time.now.to_i
           git_sha1 = `git rev-parse #{fetch(:branch)}`.chomp


### PR DESCRIPTION
### Summary

- Allow authenticating git operations over HTTPS using a token-based Authorization header, enabling builds on hosts without SSH key access to the repository.
- A temporary .gitconfig is created per host during docker:setup and cleaned up after docker:build via docker:clean.
- Also add update_git_submodule option to initialize and update submodules during clone and worktree-based builds.

### Changes

- Add docker:setup task that creates an isolated .gitconfig with http.extraheader and url.insteadOf rules when :git_auth_token is set
- Add docker:clean task to remove the temporary directory, triggered automatically after docker:build
- Wrap all remote git commands (ls-remote, clone, remote update) with git_env to inject HOME and GIT_CONFIG_NOSYSTEM environment variables
- Add tmp_home(host) and git_env(host) helper methods on the plugin class, keyed by host architecture to support multi-arch builds
- Add :update_git_submodule config variable (default false) and submodule init/update in both clone and worktree paths

